### PR TITLE
Provided default for raw_data

### DIFF
--- a/src/bottle_rest/__init__.py
+++ b/src/bottle_rest/__init__.py
@@ -56,7 +56,7 @@ def decode_json_body():
     Raises:
         HTTPError: 400 in case the data was malformed.
     """
-    raw_data = request.body.read()
+    raw_data = request.body.read() or '{}'
 
     try:
         return json.loads(raw_data)


### PR DESCRIPTION
So that the subsequent json.loads does not fail with "Expecting value: line 1 column 1 (char 0)", if json is not provided.
This way, one can handle empty input in the application and give a meaningful error message.